### PR TITLE
Implement named amethyst format and CLI argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -325,7 +325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.80"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -347,7 +347,7 @@ version = "0.1.0"
 dependencies = [
  "image 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -358,6 +358,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "sheep 0.1.0",
 ]
 
@@ -481,7 +482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
-"checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
+"checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)" = "ae8b29eb5210bc5cf63ed6149cbf9adfc82ac0be023d8735c176ee74a2db4da7"

--- a/sheep/src/format/amethyst.rs
+++ b/sheep/src/format/amethyst.rs
@@ -21,8 +21,13 @@ pub struct SerializedSpriteSheet {
 
 impl Format for AmethystFormat {
     type Data = SerializedSpriteSheet;
+    type Options = ();
 
-    fn encode(dimensions: (u32, u32), sprites: &[SpriteAnchor]) -> Self::Data {
+    fn encode(
+        dimensions: (u32, u32),
+        sprites: &[SpriteAnchor],
+        _options: Self::Options,
+    ) -> Self::Data {
         let sprite_positions = sprites
             .iter()
             .map(|it| SpritePosition {
@@ -31,7 +36,8 @@ impl Format for AmethystFormat {
                 width: it.dimensions.0 as f32,
                 height: it.dimensions.1 as f32,
                 offsets: None,
-            }).collect::<Vec<SpritePosition>>();
+            })
+            .collect::<Vec<SpritePosition>>();
 
         SerializedSpriteSheet {
             spritesheet_width: dimensions.0 as f32,

--- a/sheep/src/format/mod.rs
+++ b/sheep/src/format/mod.rs
@@ -1,10 +1,17 @@
 #[cfg(feature = "amethyst")]
 pub mod amethyst;
 
+pub mod named;
+
 use SpriteAnchor;
 
 pub trait Format {
     type Data;
+    type Options;
 
-    fn encode(dimensions: (u32, u32), sprites: &[SpriteAnchor]) -> Self::Data;
+    fn encode(
+        dimensions: (u32, u32),
+        sprites: &[SpriteAnchor],
+        options: Self::Options,
+    ) -> Self::Data;
 }

--- a/sheep/src/format/named.rs
+++ b/sheep/src/format/named.rs
@@ -1,0 +1,62 @@
+use super::Format;
+use SpriteAnchor;
+
+pub struct AmethystNamedFormat;
+
+/// `NameSprite` represents a field in a `SerializedNamedSpriteSheet`.
+/// All of the fields, except `name`, mimic the `SpritePosition` struct.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct NamedSpritePosition {
+    name: String,
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    offsets: Option<[f32; 2]>,
+}
+
+impl From<(&SpriteAnchor, String)> for NamedSpritePosition {
+    fn from(anchor: (&SpriteAnchor, String)) -> NamedSpritePosition {
+        return NamedSpritePosition {
+            name: anchor.1,
+            x: anchor.0.position.0 as f32,
+            y: anchor.0.position.1 as f32,
+            width: anchor.0.dimensions.0 as f32,
+            height: anchor.0.dimensions.1 as f32,
+            offsets: None,
+        };
+    }
+}
+
+/// `SerializedNamedSpriteSheet` is the serializable representation of the sprite sheet.
+/// It is similar to `SerializedSpriteSheet`, except that it has a `Vec` of `NamedSpritePosition`s
+/// instead of `SpriteAnchor`s
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SerializedNamedSpriteSheet {
+    spritesheet_width: f32,
+    spritesheet_height: f32,
+    sprites: Vec<NamedSpritePosition>,
+}
+
+impl Format for AmethystNamedFormat {
+    type Data = SerializedNamedSpriteSheet;
+    type Options = Vec<String>;
+
+    fn encode(
+        dimensions: (u32, u32),
+        sprites: &[SpriteAnchor],
+        options: Self::Options,
+    ) -> Self::Data {
+        let sprite_positions = sprites
+            .iter()
+            .zip(options.into_iter())
+            .map(Into::into)
+            .collect::<Vec<NamedSpritePosition>>();
+
+        SerializedNamedSpriteSheet {
+            spritesheet_width: dimensions.0 as f32,
+            spritesheet_height: dimensions.1 as f32,
+            sprites: sprite_positions,
+        }
+    }
+}

--- a/sheep/src/lib.rs
+++ b/sheep/src/lib.rs
@@ -17,6 +17,7 @@ pub use {
 
 #[cfg(feature = "amethyst")]
 pub use format::amethyst::{AmethystFormat, SerializedSpriteSheet, SpritePosition};
+pub use format::named::AmethystNamedFormat;
 
 use sprite::{create_pixel_buffer, write_sprite};
 
@@ -65,9 +66,9 @@ pub fn pack<P: Packer>(input: Vec<InputSprite>, stride: usize) -> SpriteSheet {
     }
 }
 
-pub fn encode<F>(sprite_sheet: &SpriteSheet) -> F::Data
+pub fn encode<F>(sprite_sheet: &SpriteSheet, options: F::Options) -> F::Data
 where
     F: Format,
 {
-    F::encode(sprite_sheet.dimensions, &sprite_sheet.anchors)
+    F::encode(sprite_sheet.dimensions, &sprite_sheet.anchors, options)
 }

--- a/sheep_cli/Cargo.toml
+++ b/sheep_cli/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Hilmar Wiegand <me@hwgnd.de>"]
 description = "Modular and lightweight spritesheet packer"
 
 [dependencies]
+serde = "1.0.89"
 sheep = { path = "../sheep" }
 image = "0.20"
 clap = "2.32"


### PR DESCRIPTION
I added a packer `Format` called `NamedFormat` that takes a list of file names and adds the file name without the extension as the `name` field of the serialized format.

I also added a command line arg for selecting the format, `--format`, which is optional, defaulting to `"amethyst"`. 

I'm planning on adding a similar `Format` in the Amethyst Formats. 