### PR TITLE
Sort output of packer to match input order

### DIFF
--- a/sheep/src/pack/simple.rs
+++ b/sheep/src/pack/simple.rs
@@ -70,6 +70,10 @@ impl Packer for SimplePacker {
             .expect("Invalid: No free anchors")
             .1;
 
+        // Finally sort the anchors so that they are in the same order as the
+        // input sprites
+        absolute.sort_by_key(|s| s.id);
+
         PackerResult {
             dimensions: (width, height),
             anchors: absolute,


### PR DESCRIPTION
My expectation is that the order of the sprites in the output match the order of the sprites in the input. Currently that isn't guaranteed. This changes adds that guarantee by sorting the output.

This may fix #7 though I'm not completely sure that's referring to the same problem.