### PR TITLE
Add named format to amethyst feature

### DIFF
--- a/sheep/src/format/mod.rs
+++ b/sheep/src/format/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "amethyst")]
 pub mod amethyst;
-
+#[cfg(feature = "amethyst")]
 pub mod named;
 
 use SpriteAnchor;

--- a/sheep/src/format/mod.rs
+++ b/sheep/src/format/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "amethyst")]
 pub mod amethyst;
+
 #[cfg(feature = "amethyst")]
 pub mod named;
 

--- a/sheep/src/lib.rs
+++ b/sheep/src/lib.rs
@@ -21,6 +21,7 @@ pub use {
 
 #[cfg(feature = "amethyst")]
 pub use format::amethyst::{AmethystFormat, SerializedSpriteSheet, SpritePosition};
+
 #[cfg(feature = "amethyst")]
 pub use format::named::AmethystNamedFormat;
 

--- a/sheep/src/lib.rs
+++ b/sheep/src/lib.rs
@@ -21,6 +21,7 @@ pub use {
 
 #[cfg(feature = "amethyst")]
 pub use format::amethyst::{AmethystFormat, SerializedSpriteSheet, SpritePosition};
+#[cfg(feature = "amethyst")]
 pub use format::named::AmethystNamedFormat;
 
 use sprite::{create_pixel_buffer, write_sprite};

--- a/sheep/src/lib.rs
+++ b/sheep/src/lib.rs
@@ -21,7 +21,6 @@ pub use {
 
 #[cfg(feature = "amethyst")]
 pub use format::amethyst::{AmethystFormat, SerializedSpriteSheet, SpritePosition};
-
 #[cfg(feature = "amethyst")]
 pub use format::named::AmethystNamedFormat;
 


### PR DESCRIPTION
Fixes bug from https://github.com/amethyst/sheep/issues/16.

This basically makes `AmethystNamedFormat` depend on `amethyst` feature.