### PR TITLE
Amend docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [kc]: http://keepachangelog.com/
 [sv]: http://semver.org/
 
+## Unreleased
+
+### Added
+
+- Trimming functionality added. ([#14])
+- Pretty-print functionality for toml output added ([#18])
+
+### Modified
+
+- `Named` format moved to `amethyst` feature set, removed from `default` ([#17])
+
+[#14]: https://github.com/amethyst/sheep/pull/14
+[#17]: https://github.com/amethyst/sheep/pull/17
+[#18]: https://github.com/amethyst/sheep/pull/18
+
 ## sheep 0.2.1, sheep_cli 0.2.0 - 2019-07
 
 - Initial [crates.io](https://crates.io) release

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2019 Amethyst Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This adds a few things that were forgotten in the PRs to the changelogs and fixes the apache license having a placeholder instead of the actual year and org.