### PR TITLE
Configure Travis to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: rust
 script:
   - cargo build --verbose
+  - cargo test --verbose


### PR DESCRIPTION
Right now, CI appears to just be catching build failures. This PR instructs Travis to run tests as well.

It might be a good idea to also introduce a build matrix with sheep's minimum supported Rust version, current Rust stable, and Rust nightly to catch regressions.

Another thing that could be done is porting to GitHub Actions. Since Travis-CI's Windows support is still beta, this would help sheep run tests on Windows and macOS as well, helping write tests for changes like #33.