### PR TITLE
Fix `RON` formatting for Amethyst

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,7 @@ name = "sheep_cli"
 version = "0.3.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "oxipng 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sheep/src/format/amethyst.rs
+++ b/sheep/src/format/amethyst.rs
@@ -19,8 +19,13 @@ pub struct SerializedSpriteSheet {
     pub sprites: Vec<SpritePosition>,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub enum Wrapper<T> {
+    List(T),
+}
+
 impl Format for AmethystFormat {
-    type Data = SerializedSpriteSheet;
+    type Data = Wrapper<SerializedSpriteSheet>;
     type Options = ();
 
     fn encode(
@@ -39,10 +44,10 @@ impl Format for AmethystFormat {
             })
             .collect::<Vec<SpritePosition>>();
 
-        SerializedSpriteSheet {
+        Wrapper::List(SerializedSpriteSheet {
             texture_width: dimensions.0 as f32,
             texture_height: dimensions.1 as f32,
             sprites: sprite_positions,
-        }
+        })
     }
 }

--- a/sheep_cli/Cargo.toml
+++ b/sheep_cli/Cargo.toml
@@ -23,6 +23,7 @@ clap = "2.32"
 ron = "0.4"
 oxipng = "2.2"
 png = "0.15"
+glob = "0.3"
 
 [[bin]]
 name = "sheep"


### PR DESCRIPTION
When trying to load an sprite sheet generated by the CLI using:

```rust
    let sheet_handle = {
        let loader = world.read_resource::<Loader>();
        let sheet_storage = world.read_resource::<AssetStorage<SpriteSheet>>();
        loader.load(
            "sprites/sprite_sheet.ron",
            SpriteSheetFormat(texture_handle),
            (),
            &sheet_storage,
        )
    };
```

I was getting and error due to the formatting of `sprites/sprite_sheet.ron`

```
[ERROR][amethyst_assets::progress] Error loading handle 6, Mesh, with name sprites/sprite_sheet..png: Asset was loaded but no handle to it was saved.
caused by: Asset was loaded but no handle to it was saved.
Error { inner: Inner { source: None, backtrace: None, error: UnusedHandle } }
[ERROR][amethyst_assets::progress] Note: to handle the error, use a `Progress` other than `()`
[ERROR][amethyst_assets::storage] "renderer::SpriteSheet": Asset "sprites/sprite_sheet.ron" (handle id: Handle { id: 0 }) could not be loaded: Failed to load asset with name "sprites/sprite_sheet.ron"
[ERROR][amethyst_assets::progress] Error loading handle 0, renderer::SpriteSheet, with name sprites/peakbeak.ron: Failed to load asset with name "sprites/sprite_sheet.ron"
caused by: Failed to load asset with name "sprites/sprite_sheet.ron"
Error { inner: Inner { source: Some(Error { inner: Inner { source: Some(Error { inner: Inner { source: None, backtrace: None, error: LoadSpritesheetError(Parser(ExpectedIdentifier, Position { col: 1, line: 1 })) } }), backtrace: None, error: Format("SPRITE_SHEET") } }), backtrace: None, error: Asset("sprites/peakbeak.ron") } }
caused by: Format "SPRITE_SHEET" could not load asset
Error { inner: Inner { source: Some(Error { inner: Inner { source: None, backtrace: None, error: LoadSpritesheetError(Parser(ExpectedIdentifier, Position { col: 1, line: 1 })) } }), backtrace: None, error: Format("SPRITE_SHEET") } }
caused by: Failed to parse SpriteSheet
Error { inner: Inner { source: None, backtrace: None, error: LoadSpritesheetError(Parser(ExpectedIdentifier, Position { col: 1, line: 1 })) } }
[ERROR][amethyst_assets::progress] Note: to handle the error, use a `Progress` other than `()`
```

When comparing the `ron` generated by the cli with the `ron` provided by Amethyst's examples I found out that the `Sprite` struct was wrapped with a `List` enum. So by doing the same with the output of `AmethystFormat` I managed to fix this problem.

**Note**: This PR includes a fix of #32 which I realize is fixed in #33 but was never merged and is currently outdated. If needed I can make a branch including only 
436bec5 .