### PR TITLE
Expose NamedSpritePosition to Amethyst

### DIFF
--- a/sheep/src/lib.rs
+++ b/sheep/src/lib.rs
@@ -25,7 +25,7 @@ pub use {
 #[cfg(feature = "amethyst")]
 pub use format::amethyst::{AmethystFormat, SerializedSpriteSheet, SpritePosition};
 #[cfg(feature = "amethyst")]
-pub use format::named::{AmethystNamedFormat, SerializedNamedSpriteSheet};
+pub use format::named::{AmethystNamedFormat, NamedSpritePosition, SerializedNamedSpriteSheet};
 
 use sprite::{create_pixel_buffer, write_sprite};
 


### PR DESCRIPTION
NamedSpritePosition is necessary to implement amethyst::assets::Format correctly.

Sorry to piecemeal the Amethyst interop, stuff. I've been away from amethyst for a while.